### PR TITLE
feat: deploy VMs

### DIFF
--- a/roles/vm/tasks/main.yml
+++ b/roles/vm/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+# VM Creation testings.
+# Missing: reclaim option on disk, HA settings
+
+# TODO
+# - Add the VM to the target HA Group
+
+- name: Create VM
+  community.general.proxmox_kvm:
+    api_user: '{{ proxmox_api_user }}'
+    api_token_id: '{{ proxmox_api_token_id }}'
+    api_token_secret: '{{ proxmox_api_token_secret }}'
+    api_host: '{{ proxmox_api_host }}'
+    node: '{{ item.node }}'
+    name: '{{ item.name }}'
+    vmid: '{{ item.vmid }}'
+    net: '{{ item.net }}'
+    cores: '{{ item.cores }}'
+    memory: '{{ item.memory }}'
+    virtio: '{{ item.virtio }}'
+  retries: 10
+  delay: 3
+  register: vm
+  until: vm.vmid is defined
+  loop: '{{ pve_kvm }}'
+
+- name: start VM
+  community.general.proxmox_kvm:
+    api_user: '{{ proxmox_api_user }}'
+    api_token_id: '{{ proxmox_api_token_id }}'
+    api_token_secret: '{{ proxmox_api_token_secret }}'
+    api_host: '{{ proxmox_api_host }}'
+    node: '{{ item.node }}'
+    name: '{{ item.name }}'
+    state: started
+  retries: 10
+  delay: 3
+  register: vm
+  until: vm.vmid is defined
+  loop: '{{ pve_kvm }}'


### PR DESCRIPTION
This feature enables the operator to create VMs to a PVE Cluster from an array.
VMs must be defined in the `pve_kvm` array
What's working:
- VM Creation
- VM auto start after creation
- basic hardware settings (RAM,Cores, VMID, Net, Disks)