### PR TITLE
Add new role patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,6 @@ The below requirements are needed on the host that executes this collection:
 ## Roles
 
 * [container](roles/container/README.md)
-* [vm](roles/vm/README.md)
 * [ha](roles/ha/README.md)
+* [patch](roles/patch/README.md)
+* [vm](roles/vm/README.md)

--- a/roles/patch/README.md
+++ b/roles/patch/README.md
@@ -1,0 +1,11 @@
+# mila.proxmox.patch
+
+The role `mila.proxmox.patch` allows to apply pre-defined patches on top of the
+Proxmox installation. By default, no patch are applied, this is an opt-in
+feature.
+
+## List of patches
+
+- Allow configuration of CT/VM with a token for root@pam
+  - URL: https://bugzilla.proxmox.com/show_bug.cgi?id=3829
+  - Enable with: `proxmox_patch_3829: True`

--- a/roles/patch/defaults/main.yml
+++ b/roles/patch/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+proxmox_patch_3829: false

--- a/roles/patch/files/3829-Allow-tokens-root-pam-to-modify-ct-config.patch
+++ b/roles/patch/files/3829-Allow-tokens-root-pam-to-modify-ct-config.patch
@@ -1,0 +1,25 @@
+From a2167a468cccf1797b38509d5c3994ea245bc6c3 Mon Sep 17 00:00:00 2001
+From: Bruno Travouillon <devel@travouillon.fr>
+Date: Mon, 17 Jan 2022 11:03:28 -0500
+Subject: [PATCH] Allow tokens root@pam to modify ct config
+
+---
+ src/PVE/LXC.pm | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/PVE/LXC.pm b/src/PVE/LXC.pm
+index b07d986..83294ca 100644
+--- a/src/PVE/LXC.pm
++++ b/src/PVE/LXC.pm
+@@ -1254,7 +1254,7 @@ sub template_create {
+ sub check_ct_modify_config_perm {
+     my ($rpcenv, $authuser, $vmid, $pool, $oldconf, $newconf, $delete, $unprivileged) = @_;
+
+-    return 1 if $authuser eq 'root@pam';
++    return 1 if (substr($authuser, 0, 8)) eq 'root@pam';
+     my $storage_cfg = PVE::Storage::config();
+
+     my $check = sub {
+--
+2.30.2
+

--- a/roles/patch/files/3829-Allow-tokens-root-pam-to-modify-vm-config.patch
+++ b/roles/patch/files/3829-Allow-tokens-root-pam-to-modify-vm-config.patch
@@ -1,0 +1,43 @@
+From 6e39e66e682a5364a9255f67f525ba20acca729f Mon Sep 17 00:00:00 2001
+From: Bruno Travouillon <bruno.travouillon@mila.quebec>
+Date: Tue, 19 Apr 2022 12:17:32 -0400
+Subject: [PATCH] Allow tokens root@pam to modify vm config
+
+---
+ PVE/API2/Qemu.pm | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/PVE/API2/Qemu.pm b/PVE/API2/Qemu.pm
+index 3af2132..c6bde5f 100644
+--- a/PVE/API2/Qemu.pm
++++ b/PVE/API2/Qemu.pm
+@@ -549,7 +549,7 @@ my $cloudinitoptions = {
+ my $check_vm_create_serial_perm = sub {
+     my ($rpcenv, $authuser, $vmid, $pool, $param) = @_;
+
+-    return 1 if $authuser eq 'root@pam';
++    return 1 if (substr($authuser, 0, 8)) eq 'root@pam';
+
+     foreach my $opt (keys %{$param}) {
+ 	next if $opt !~ m/^serial\d+$/;
+@@ -567,7 +567,7 @@ my $check_vm_create_serial_perm = sub {
+ my $check_vm_create_usb_perm = sub {
+     my ($rpcenv, $authuser, $vmid, $pool, $param) = @_;
+
+-    return 1 if $authuser eq 'root@pam';
++    return 1 if (substr($authuser, 0, 8)) eq 'root@pam';
+
+     foreach my $opt (keys %{$param}) {
+ 	next if $opt !~ m/^usb\d+$/;
+@@ -585,7 +585,7 @@ my $check_vm_create_usb_perm = sub {
+ my $check_vm_modify_config_perm = sub {
+     my ($rpcenv, $authuser, $vmid, $pool, $key_list) = @_;
+
+-    return 1 if $authuser eq 'root@pam';
++    return 1 if (substr($authuser, 0, 8)) eq 'root@pam';
+
+     foreach my $opt (@$key_list) {
+ 	# some checks (e.g., disk, serial port, usb) need to be done somewhere
+--
+2.30.2
+

--- a/roles/patch/handlers/main.yml
+++ b/roles/patch/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart pvedaemon.service
+  ansible.builtin.systemd:
+    name: pvedaemon.service
+    state: restarted

--- a/roles/patch/tasks/main.yml
+++ b/roles/patch/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Ensure patch is installed
+  ansible.builtin.package:
+    name: patch
+
+- name: Patch https://bugzilla.proxmox.com/show_bug.cgi?id=3829
+  ansible.posix.patch:
+    src: '3829-Allow-tokens-root-pam-to-modify-ct-config.patch'
+    basedir: '/usr/share/perl5'
+    strip: 2
+  notify: Restart pvedaemon.service
+  when: proxmox_patch_3829
+
+- name: Patch https://bugzilla.proxmox.com/show_bug.cgi?id=3829
+  ansible.posix.patch:
+    src: '3829-Allow-tokens-root-pam-to-modify-vm-config.patch'
+    basedir: '/usr/share/perl5'
+    strip: 1
+  notify: Restart pvedaemon.service
+  when: proxmox_patch_3829


### PR DESCRIPTION
This role allows to apply patches on top of a Proxmox installation. By default,
no patch are applied, this is an opt-in feature.