### PR TITLE
feat: enable cpu setting for VMs

### DIFF
--- a/roles/vm/tasks/main.yml
+++ b/roles/vm/tasks/main.yml
@@ -19,6 +19,7 @@
     memory: '{{ item.memory }}'
     virtio: '{{ item.virtio }}'
     hostpci: '{{ item.hostpci | default(omit) }}'
+    cpu: '{{ item.cpu | default(omit) }}'
     validate_certs: "{{ proxmox_api_validate_certs }}"
   retries: 10
   delay: 3


### PR DESCRIPTION
default is kvm64 (source: https://docs.ansible.com/ansible/latest/collections/community/general/proxmox_kvm_module.html)