### PR TITLE
feat: add update var to vm role

### DIFF
--- a/roles/vm/tasks/main.yml
+++ b/roles/vm/tasks/main.yml
@@ -1,11 +1,7 @@
 ---
 # VM Creation testings.
-# Missing: reclaim option on disk, HA settings
 
-# TODO
-# - Add the VM to the target HA Group
-
-- name: Create VM
+- name: Create / Update VM
   community.general.proxmox_kvm:
     api_host: "{{ proxmox_api_host }}"
     api_token_id: "{{ proxmox_api_token_id }}"
@@ -22,6 +18,7 @@
     node: "{{ item.node }}"
     scsi: "{{ item.scsi | default(omit) }}"
     scsihw: "{{ item.scsihw | default(omit) }}"
+    update: "{{ item.update | default(omit) }}"
     validate_certs: "{{ proxmox_api_validate_certs }}"
     virtio: "{{ item.virtio | default(omit) }}"
     vmid: "{{ item.vmid }}"


### PR DESCRIPTION
This var enables us to make updates on existing VM, as per module documentation example:

```
- name: Update VM configuration
  community.general.proxmox_kvm:
    api_user: root@pam
    api_password: secret
    api_host: helldorado
    name: spynal
    node: sabrewulf
    cores: 8
    memory: 16384
    update: yes
```