### PR TITLE
fix: use refresh instead of update var

### DIFF
--- a/roles/vm/tasks/main.yml
+++ b/roles/vm/tasks/main.yml
@@ -18,7 +18,7 @@
     node: "{{ item.node }}"
     scsi: "{{ item.scsi | default(omit) }}"
     scsihw: "{{ item.scsihw | default(omit) }}"
-    update: "{{ item.update | default(omit) }}"
+    update: "{{ item.refresh | default(omit) }}"  # do NOT use item.update ! Seen as python method from ansible POV
     validate_certs: "{{ proxmox_api_validate_certs }}"
     virtio: "{{ item.virtio | default(omit) }}"
     vmid: "{{ item.vmid }}"

--- a/roles/vm/tasks/main.yml
+++ b/roles/vm/tasks/main.yml
@@ -18,7 +18,7 @@
     node: "{{ item.node }}"
     scsi: "{{ item.scsi | default(omit) }}"
     scsihw: "{{ item.scsihw | default(omit) }}"
-    update: "{{ item.refresh | default(omit) }}"  # do NOT use item.update ! Seen as python method from ansible POV
+    update: "{{ item.refresh | default(omit) }}"
     validate_certs: "{{ proxmox_api_validate_certs }}"
     virtio: "{{ item.virtio | default(omit) }}"
     vmid: "{{ item.vmid }}"


### PR DESCRIPTION
See https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#ansible-allows-dot-notation-and-array-notation-for-variables-which-notation-should-i-use

Previous var made the plays fails because `item.update` is a python method that is always defined.

```
"msg": "argument 'update' is of type <class 'str'> and we were unable to convert to bool: The value '<built-in method update of dict object at 0x7fb2baec0d00>' is not a valid boolean.
```