### PR TITLE
feat: Allow to update VMs with new values

### DIFF
--- a/roles/vm/README.md
+++ b/roles/vm/README.md
@@ -34,3 +34,7 @@ By default, the proxmox modules in `community.general` do not validate SSL
 certs. To enable certificate validation, define the variable:
 
  - `proxmox_api_validate_certs: true`
+
+To enable update of VMs with new values:
+
+ - `proxmox_kvm_update: true`

--- a/roles/vm/defaults/main.yml
+++ b/roles/vm/defaults/main.yml
@@ -5,3 +5,6 @@
 # certs. Make this a default for use with other modules like
 # `ansible.builtin.uri` (used for API calls)
 proxmox_api_validate_certs: false
+
+# Do not update the VM when proxmox_kvm runs
+proxmox_kvm_update: false

--- a/roles/vm/tasks/main.yml
+++ b/roles/vm/tasks/main.yml
@@ -17,7 +17,12 @@
     scsi: "{{ item.scsi | default(omit) }}"
     scsihw: "{{ item.scsihw | default(omit) }}"
     tags: "{{ item.tags | default(omit) }}"
-    update: "{{ item.refresh | default(omit) }}"
+    update: "
+      {% if 'update' in item %}
+      {{ item['update'] }}
+      {% else %}
+      {{ proxmox_kvm_update }}
+      {% endif %}"
     validate_certs: "{{ proxmox_api_validate_certs }}"
     virtio: "{{ item.virtio | default(omit) }}"
     vmid: "{{ item.vmid }}"


### PR DESCRIPTION
Because the proxmox_kvm module is not idempotent when `update: true`, add a new variable `proxmox_kvm_update` that allows to run the update on demand.

Also replace `refresh` with `update` which is more accurate and matches the name of the module parameter. Note that `item.update` is not usable since `update` is a method of python dicts. Ensure that `update` is defined before using it.

Closes: #30
Fixes: #29