### PR TITLE
fix: remove deprecated proxmox_default_behavior

### DIFF
--- a/roles/container/README.md
+++ b/roles/container/README.md
@@ -27,8 +27,7 @@ all hosts.
 Most of the parameters supported by the module `community.general.proxmox` can
 be defined in the list. The following parameters are not supported yet, but
 this might change in future development: `api_password`, `ip_address`, 
-`password`, `pool`, `purge`, `searchdomain` and `storage`. Note that
-`proxmox_default_behavior` is enforced to `no_defaults`.
+`password`, `pool`, `purge`, `searchdomain` and `storage`.
 
 To authenticate to the REST API of your Proxmox VE cluster, you first need to
 create an [API token][pve_api_tokens], then you must define the 4 **mandatory**

--- a/roles/container/tasks/create.yml
+++ b/roles/container/tasks/create.yml
@@ -1,7 +1,6 @@
 ---
 - name: Setup LXC Containers
   community.general.proxmox:
-    proxmox_default_behavior: 'no_defaults'
     api_host: "{{ proxmox_api_host }}"
     api_token_id: "{{ item.api_token_id | default(proxmox_api_token_id) }}"
     api_token_secret: "{{ item.api_token_secret | default(proxmox_api_token_secret) }}"
@@ -35,7 +34,6 @@
 
 - name: Start Containers
   community.general.proxmox:
-    proxmox_default_behavior: 'no_defaults'
     api_host: "{{ proxmox_api_host }}"
     api_user: "{{ proxmox_api_user }}"
     api_token_id: "{{ proxmox_api_token_id }}"

--- a/roles/container/tasks/destroy.yml
+++ b/roles/container/tasks/destroy.yml
@@ -1,7 +1,6 @@
 ---
 - name: Stop Containers
   community.general.proxmox:
-    proxmox_default_behavior: 'no_defaults'
     api_host: "{{ proxmox_api_host }}"
     api_user: "{{ proxmox_api_user }}"
     api_token_id: "{{ proxmox_api_token_id }}"
@@ -14,7 +13,6 @@
 
 - name: Destroy Containers
   community.general.proxmox:
-    proxmox_default_behavior: 'no_defaults'
     api_host: "{{ proxmox_api_host }}"
     api_user: "{{ proxmox_api_user }}"
     api_token_id: "{{ proxmox_api_token_id }}"


### PR DESCRIPTION
This parameter is deprecated and will be removed in community.general 10.0.0.