### PR TITLE
feat: Allow to update containers with new values

### DIFF
--- a/roles/container/README.md
+++ b/roles/container/README.md
@@ -134,3 +134,7 @@ role `mila.proxmox.container` in the pre_tasks of your playbook, with
 In the example above, ansible-playbook must run with `-e
 proxmox_container_destroy_first=True` for the destruction of the containers to
 be effective.
+
+To enable update of LXC containers with new values:
+
+ - `proxmox_container_update: true`

--- a/roles/container/defaults/main.yml
+++ b/roles/container/defaults/main.yml
@@ -5,3 +5,6 @@
 # certs. Make this a default for use with other modules like
 # `ansible.builtin.uri` (used for API calls)
 proxmox_api_validate_certs: false
+
+# Do not update the container when proxmox runs
+proxmox_container_update: false

--- a/roles/container/tasks/create.yml
+++ b/roles/container/tasks/create.yml
@@ -28,6 +28,12 @@
     swap: "{{ item.swap | default(0) }}"
     timeout: "{{ item.timeout | default(120) }}"
     unprivileged: "{{ item.unprivileged | default(omit) }}"
+    update: "
+      {% if 'update' in item %}
+      {{ item['update'] }}
+      {% else %}
+      {{ proxmox_container_update }}
+      {% endif %}"
     validate_certs: "{{ item.validate_certs | default(proxmox_api_validate_certs) | bool }}"
     vmid: "{{ item.vmid | default(omit) }}"
   loop: "{{ proxmox_container }}"


### PR DESCRIPTION
Add a new variable `proxmox_container_update` that allows to run the update on demand.

Note that `item.update` is not usable since `update` is a method of python dicts. Ensure that `update` is defined before using it.