### PR TITLE
fix: Remove support of force parameter for VMs

### DIFF
--- a/roles/vm/tasks/main.yml
+++ b/roles/vm/tasks/main.yml
@@ -25,7 +25,6 @@
     description: "{{ item.description | default(omit)  }}"
     digest: "{{ item.digest | default(omit)  }}"
     efidisk0: "{{ item.efidisk0 | default(omit)  }}"
-    force: "{{ item.force | default(omit) | bool }}"
     format: "{{ item.format | default(omit) }}"
     freeze: "{{ item.freeze | default(omit) }}"
     full: "{{ item.full | default(omit) }}"


### PR DESCRIPTION
The behaviour is different with module proxmox_kvm than with module proxmox (for CTs). Since `force` requires `archive` which is not supported by this role, simply drop support of `force`.

Closes: #43