### PR TITLE
Set the instance root password while container creates

### DIFF
--- a/roles/container/tasks/create.yml
+++ b/roles/container/tasks/create.yml
@@ -23,6 +23,7 @@
     node: "{{ item.node }}"
     onboot: "{{ item.onboot | default(False) }}"
     ostemplate: "{{ item.ostemplate }}"
+    password: "{{ item.password | default(omit) }}"
     pubkey: "{{ item.pubkey | default(proxmox_pubkey) | default(omit) }}"
     state: "{{ item.state | default('present') }}"
     swap: "{{ item.swap | default(0) }}"
@@ -30,7 +31,6 @@
     unprivileged: "{{ item.unprivileged | default(omit) }}"
     validate_certs: "{{ item.validate_certs | default(proxmox_api_validate_certs) | bool }}"
     vmid: "{{ item.vmid | default(omit) }}"
-    password: "{{ item.password | default(omit) }}"
   loop: "{{ proxmox_container }}"
 
   # ostemplate and update are mutually exclusive

--- a/roles/container/tasks/create.yml
+++ b/roles/container/tasks/create.yml
@@ -30,6 +30,7 @@
     unprivileged: "{{ item.unprivileged | default(omit) }}"
     validate_certs: "{{ item.validate_certs | default(proxmox_api_validate_certs) | bool }}"
     vmid: "{{ item.vmid | default(omit) }}"
+    password: "{{ item.password | default(omit) }}"
   loop: "{{ proxmox_container }}"
 
   # ostemplate and update are mutually exclusive


### PR DESCRIPTION
Add the capability to set an instance root password of a container

[Link to Docs](https://docs.ansible.com/ansible/latest/collections/community/general/proxmox_module.html#parameter-password)