### PR TITLE
Use community.proxmox instead of community.general

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ change quickly and without notice while version is still 0.x.y.
 
 The below requirements are needed on the host that executes this collection:
 
- - collection `community.general`
+ - collection `community.proxmox`
  - jmespath
  - proxmoxer
  - requests

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -44,7 +44,7 @@ tags:
 # collection label 'namespace.name'. The value is a version range
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
-dependencies: {community.general: '>4.0.0'}
+dependencies: {community.proxmox: '>1.0.0'}
 
 # The URL of the originating SCM repository
 repository: https://github.com/mila-iqia/ansible-collection-proxmox

--- a/roles/container/README.md
+++ b/roles/container/README.md
@@ -1,8 +1,8 @@
 # mila.proxmox.container
 
 To manage containers, use the role `mila.proxmox.container`. This role makes use
-of the Ansible modules `community.general.proxmox_template` and
-`community.general.proxmox`.
+of the Ansible modules `community.proxmox.proxmox_template` and
+`community.proxmox.proxmox`.
 
 The containers are created from a list defined in `proxmox_container`. Each item
 in the list defines one container.
@@ -24,7 +24,7 @@ Example for a container:
 The role will parse `ostemplate` to ensure the required template is available on
 all hosts.
 
-Most of the parameters supported by the module `community.general.proxmox` can
+Most of the parameters supported by the module `community.proxmox.proxmox` can
 be defined in the list. The following parameters are not supported yet, but
 this might change in future development: `api_password`, `ip_address`, 
 `password`, `pool`, `purge`, `searchdomain` and `storage`.
@@ -57,7 +57,7 @@ In the example above, `item.api_user` and `item.api_token_secret` will
 respectively replace the values of `proxmox_api_user` and
 `proxmox_api_token_secret`.
 
-By default, the proxmox modules in `community.general` do not validate SSL
+By default, the proxmox modules in `community.proxmox` do not validate SSL
 certs. To enable certificate validation, define the variable:
 
  - `proxmox_api_validate_certs: true`
@@ -101,7 +101,7 @@ Ansible inventory.
 
 
 Once a container exists, some parameters cannot be changed with the
-`community.general.proxmox` module. To circumvent this limitation, it is
+`community.proxmox.proxmox` module. To circumvent this limitation, it is
 possible to destroy the containers and recreate these. For this, include the
 role `mila.proxmox.container` in the pre_tasks of your playbook, with
 `tasks_from: destroy`.

--- a/roles/container/defaults/main.yml
+++ b/roles/container/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Define if the SSL certificates must be validated
 #
-# By default, the proxmox modules in `community.general` do not validate SSL
+# By default, the proxmox modules in `community.proxmox` do not validate SSL
 # certs. Make this a default for use with other modules like
 # `ansible.builtin.uri` (used for API calls)
 proxmox_api_validate_certs: false

--- a/roles/container/tasks/create.yml
+++ b/roles/container/tasks/create.yml
@@ -1,6 +1,6 @@
 ---
 - name: Setup LXC Containers
-  community.general.proxmox:
+  community.proxmox.proxmox:
     api_host: "{{ proxmox_api_host }}"
     api_token_id: "{{ item.api_token_id | default(proxmox_api_token_id) }}"
     api_token_secret: "{{ item.api_token_secret | default(proxmox_api_token_secret) }}"
@@ -35,7 +35,7 @@
 
   # ostemplate and update are mutually exclusive
 - name: Update LXC Containers
-  community.general.proxmox:
+  community.proxmox.proxmox:
     api_host: "{{ proxmox_api_host }}"
     api_token_id: "{{ item.api_token_id | default(proxmox_api_token_id) }}"
     api_token_secret: "{{ item.api_token_secret | default(proxmox_api_token_secret) }}"
@@ -71,7 +71,7 @@
   loop: "{{ proxmox_container }}"
 
 - name: Manage Containers state
-  community.general.proxmox:
+  community.proxmox.proxmox:
     api_host: "{{ proxmox_api_host }}"
     api_user: "{{ proxmox_api_user }}"
     api_token_id: "{{ proxmox_api_token_id }}"

--- a/roles/container/tasks/destroy.yml
+++ b/roles/container/tasks/destroy.yml
@@ -1,6 +1,6 @@
 ---
 - name: Stop Containers
-  community.general.proxmox:
+  community.proxmox.proxmox:
     api_host: "{{ proxmox_api_host }}"
     api_user: "{{ proxmox_api_user }}"
     api_token_id: "{{ proxmox_api_token_id }}"
@@ -12,7 +12,7 @@
   loop: "{{ proxmox_container }}"
 
 - name: Destroy Containers
-  community.general.proxmox:
+  community.proxmox.proxmox:
     api_host: "{{ proxmox_api_host }}"
     api_user: "{{ proxmox_api_user }}"
     api_token_id: "{{ proxmox_api_token_id }}"

--- a/roles/container/tasks/install_templates.yml
+++ b/roles/container/tasks/install_templates.yml
@@ -17,7 +17,7 @@
     __ostemplate_regex: '^([-a-z0-9]+):([a-z]+)/(.*)'
 
 - name: Download proxmox appliance container templates
-  community.general.proxmox_template:
+  community.proxmox.proxmox_template:
     api_host: "{{ proxmox_api_host }}"
     api_user: "{{ proxmox_api_user }}"
     api_token_id: "{{ proxmox_api_token_id }}"

--- a/roles/ha/README.md
+++ b/roles/ha/README.md
@@ -31,7 +31,7 @@ variables below:
 
 [pve_api_tokens]: https://pve.proxmox.com/pve-docs/chapter-pveum.html#pveum_tokens
 
-By default, the proxmox modules in `community.general` do not validate SSL
+By default, the proxmox modules in `community.proxmox` do not validate SSL
 certs. To enable certificate validation, define the variable:
 
  - `proxmox_api_validate_certs: true`

--- a/roles/ha/defaults/main.yml
+++ b/roles/ha/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Define if the SSL certificates must be validated
 #
-# By default, the proxmox modules in `community.general` do not validate SSL
+# By default, the proxmox modules in `community.proxmox` do not validate SSL
 # certs. Make this a default for use with other modules like
 # `ansible.builtin.uri` (used for API calls)
 proxmox_api_validate_certs: false

--- a/roles/vm/README.md
+++ b/roles/vm/README.md
@@ -1,7 +1,7 @@
 # mila.proxmox.vm
 
 To manage virtual machines, use the role `mila.proxmox.vm`. This role makes use
-of the Ansible modules `community.general.proxmox_kvm`.
+of the Ansible module `community.proxmox.proxmox_kvm`.
 
 The VMs are created from a list defined in `proxmox_vm`. Each item
 in the list defines one VM.
@@ -32,7 +32,7 @@ variables below:
 
 [pve_api_tokens]: https://pve.proxmox.com/pve-docs/chapter-pveum.html#pveum_tokens
 
-By default, the proxmox modules in `community.general` do not validate SSL
+By default, the proxmox modules in `community.proxmox` do not validate SSL
 certs. To enable certificate validation, define the variable:
 
  - `proxmox_api_validate_certs: true`

--- a/roles/vm/defaults/main.yml
+++ b/roles/vm/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Define if the SSL certificates must be validated
 #
-# By default, the proxmox modules in `community.general` do not validate SSL
+# By default, the proxmox modules in `community.proxmox` do not validate SSL
 # certs. Make this a default for use with other modules like
 # `ansible.builtin.uri` (used for API calls)
 proxmox_api_validate_certs: false

--- a/roles/vm/tasks/main.yml
+++ b/roles/vm/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Setup VM
-  community.general.proxmox_kvm:
+  community.proxmox.proxmox_kvm:
     api_host: "{{ proxmox_api_host }}"
     api_token_id: "{{ proxmox_api_token_id }}"
     api_token_secret: "{{ proxmox_api_token_secret }}"
@@ -80,7 +80,7 @@
   loop: "{{ proxmox_vm }}"
 
 - name: Manage VM state
-  community.general.proxmox_kvm:
+  community.proxmox.proxmox_kvm:
     api_host: "{{ proxmox_api_host }}"
     api_token_id: "{{ proxmox_api_token_id }}"
     api_token_secret: "{{ proxmox_api_token_secret }}"


### PR DESCRIPTION
The Proxmox content (modules and plugins) has been moved to the new collection community.proxmox. Since community.general 11.0.0, these modules and plugins have been replaced by deprecated redirections to community.proxmox.

The Ansible team suggests to update the roles and playbooks to use the new FQCNs as soon as possible to avoid getting deprecation messages