### PR TITLE
Configure HA resources for VM and CT

### DIFF
--- a/roles/container/README.md
+++ b/roles/container/README.md
@@ -138,3 +138,36 @@ be effective.
 To enable update of LXC containers with new values:
 
  - `proxmox_container_update: true`
+
+## High Availability (HA) Resources
+
+The role supports configuring HA resources for containers. To enable HA for a container,
+add an `ha` key to the container definition. The `ha.state` parameter is mandatory.
+
+Example with HA configuration:
+
+    proxmox_container:
+      - hostname: 'container1'
+        node: 'pve-1'
+        ostemplate: 'local:vztmpl/debian-11-standard_11.0-1_amd64.tar.gz'
+        disk: 'local:2'
+        cores: 2
+        nameserver: '10.10.0.1'
+        netif: '{"net0":"name=eth0,gw=10.10.0.254,hwaddr=42:4d:69:6c:61:00,ip=dhcp,bridge=vmbr0"}'
+        unprivileged: True
+        ha:
+          state: 'present'
+          comment: 'Critical service container'
+          hastate: 'started'
+          max_relocate: 3
+          max_restart: 5
+
+Supported HA parameters:
+- `state`: (mandatory) The state of the HA resource (`present` or `absent`)
+- `comment`: Optional comment for the HA resource
+- `hastate`: The desired HA state
+- `max_relocate`: Maximum number of relocations
+- `max_restart`: Maximum number of restarts
+
+If the `ha` key is not defined for a container, any existing HA resource for that
+container will be removed.

--- a/roles/container/tasks/main.yml
+++ b/roles/container/tasks/main.yml
@@ -6,3 +6,31 @@
 - name: Import tasks to create containers
   ansible.builtin.include_tasks:
     file: create.yml
+
+- name: Configure HA resources
+  community.proxmox.proxmox_cluster_ha_resources:
+    api_host: "{{ proxmox_api_host }}"
+    api_token_id: "{{ proxmox_api_token_id }}"
+    api_token_secret: "{{ proxmox_api_token_secret }}"
+    api_user: "{{ proxmox_api_user }}"
+    comment: "{{ item.ha.comment | default(omit) }}"
+    hastate: "{{ item.ha.hastate | default(omit) }}"
+    max_relocate: "{{ item.ha.max_relocate | default(omit) }}"
+    max_restart: "{{ item.ha.max_restart | default(omit) }}"
+    name: "ct:{{ item.vmid }}"
+    state: "{{ item.ha.state | mandatory }}"
+    validate_certs: "{{ proxmox_api_validate_certs }}"
+  when: item.ha is defined
+  loop: "{{ proxmox_container }}"
+
+- name: Remove HA resources
+  community.proxmox.proxmox_cluster_ha_resources:
+    api_host: "{{ proxmox_api_host }}"
+    api_token_id: "{{ proxmox_api_token_id }}"
+    api_token_secret: "{{ proxmox_api_token_secret }}"
+    api_user: "{{ proxmox_api_user }}"
+    name: "ct:{{ item.vmid }}"
+    state: "absent"
+    validate_certs: "{{ proxmox_api_validate_certs }}"
+  when: not item.ha is defined
+  loop: "{{ proxmox_container }}"

--- a/roles/vm/README.md
+++ b/roles/vm/README.md
@@ -40,3 +40,38 @@ certs. To enable certificate validation, define the variable:
 To enable update of VMs with new values:
 
  - `proxmox_kvm_update: true`
+
+## High Availability (HA) Resources
+
+The role supports configuring HA resources for virtual machines. To enable HA for a VM,
+add an `ha` key to the VM definition. The `ha.state` parameter is mandatory.
+
+Example with HA configuration:
+
+```
+pve_kvm:
+  - name: "critical-vm"
+    vmid: 1001
+    node: pve-1
+    net:
+      net0: virtio=42:49:54:11:01:00,bridge=vmbr0,tag=2
+    cores: 4
+    memory: 8192
+    virtio:
+      virtio0: vm-storage:64
+    ha:
+      state: 'present'
+      comment: 'Critical production VM'
+      hastate: 'started'
+      max_relocate: 3
+      max_restart: 5
+```
+
+Supported HA parameters:
+- `state`: (mandatory) The state of the HA resource (`present` or `absent`)
+- `comment`: Optional comment for the HA resource
+- `hastate`: The desired HA state
+- `max_relocate`: Maximum number of relocations
+- `max_restart`: Maximum number of restarts
+
+If the `ha` key is not defined for a VM, any existing HA resource for that VM will be removed.

--- a/roles/vm/tasks/main.yml
+++ b/roles/vm/tasks/main.yml
@@ -95,3 +95,31 @@
   register: vm
   until: vm.vmid is defined
   loop: "{{ proxmox_vm }}"
+
+- name: Configure HA resources
+  community.proxmox.proxmox_cluster_ha_resources:
+    api_host: "{{ proxmox_api_host }}"
+    api_token_id: "{{ proxmox_api_token_id }}"
+    api_token_secret: "{{ proxmox_api_token_secret }}"
+    api_user: "{{ proxmox_api_user }}"
+    comment: "{{ item.ha.comment | default(omit) }}"
+    hastate: "{{ item.ha.hastate | default(omit) }}"
+    max_relocate: "{{ item.ha.max_relocate | default(omit) }}"
+    max_restart: "{{ item.ha.max_restart | default(omit) }}"
+    name: "vm:{{ item.vmid }}"
+    state: "{{ item.ha.state | mandatory }}"
+    validate_certs: "{{ proxmox_api_validate_certs }}"
+  when: item.ha is defined
+  loop: "{{ proxmox_vm }}"
+
+- name: Remove HA resources
+  community.proxmox.proxmox_cluster_ha_resources:
+    api_host: "{{ proxmox_api_host }}"
+    api_token_id: "{{ proxmox_api_token_id }}"
+    api_token_secret: "{{ proxmox_api_token_secret }}"
+    api_user: "{{ proxmox_api_user }}"
+    name: "vm:{{ item.vmid }}"
+    state: "absent"
+    validate_certs: "{{ proxmox_api_validate_certs }}"
+  when: not item.ha is defined
+  loop: "{{ proxmox_vm }}"


### PR DESCRIPTION
Introduce a new key `ha` in the `proxmox_container` and `proxmox_vm` definitions that allows to define resources properties within the CT/VM configuration.

The `ha.state` is mandatory.

This change may help to deprecate the role `mila.proxmox.ha` which only supports the [deprecated HA Groups](https://pve.proxmox.com/pve-docs/chapter-ha-manager.html#ha_manager_groups) configuration.